### PR TITLE
Add Selenium-based XNAT regression test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
+# XNAT Selenium Test Suite
 
+End-to-end Selenium tests that exercise key workflows in an XNAT deployment. The
+suite focuses on authentication, project management, subject onboarding, and
+basic imaging session registration so that new releases of an XNAT instance can
+be validated automatically.
+
+## Features
+
+- Page Object Model abstractions for core XNAT screens (login, dashboard,
+  projects, subjects, experiments).
+- Pytest-powered fixtures that create browsers locally or via a remote Selenium
+  grid, with configuration coming from environment variables or command line
+  options.
+- Smoke-level authentication coverage and a full project lifecycle scenario that
+  provisions a project, subject, and imaging session.
+- Marker definitions (`smoke`, `projects`, `e2e`) to aid targeted execution in
+  CI pipelines.
+
+## Getting started
+
+1. Install dependencies (Python 3.10+):
+
+   ```bash
+   pip install -e .
+   ```
+
+2. Provide credentials and connection details for the target XNAT environment
+   using environment variables or Pytest command line flags:
+
+   - `XNAT_BASE_URL` / `--base-url`
+   - `XNAT_USERNAME` / `--username`
+   - `XNAT_PASSWORD` / `--password`
+   - Optional: `XNAT_HEADLESS=0` (or use `--headed`) to run browsers with a UI.
+   - Optional: `SELENIUM_REMOTE_URL` / `--remote-url` when using a Selenium
+     server such as Selenium Grid or BrowserStack.
+
+3. Run the tests:
+
+   ```bash
+   pytest
+   ```
+
+   Run only the fast smoke tests:
+
+   ```bash
+   pytest -m smoke
+   ```
+
+   Execute the end-to-end project lifecycle scenario:
+
+   ```bash
+   pytest -m e2e
+   ```
+
+## Project structure
+
+```
+src/xnat_selenium/      # Page objects and configuration helpers
+└── pages/              # Specific page abstractions (login, dashboard, etc.)
+tests/                  # Pytest suites leveraging the page objects
+pyproject.toml          # Python package metadata and dependencies
+pytest.ini              # Marker registration and Pytest defaults
+```
+
+## Notes
+
+- The suite assumes the target XNAT instance uses the default user interface
+  structure and element identifiers. Custom themes may require selector
+  adjustments inside the page objects.
+- Project, subject, and experiment names are generated dynamically to avoid
+  collisions between repeated runs. Clean-up logic can be added if required by
+  your governance policies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "xnat-selenium-tests"
+version = "0.1.0"
+description = "Selenium-based end-to-end regression tests for XNAT deployments"
+authors = [{name = "Automation", email = "automation@example.com"}]
+requires-python = ">=3.10"
+dependencies = [
+    "pytest>=7.4",
+    "selenium>=4.13",
+]
+
+[build-system]
+requires = ["setuptools>=65"]
+build-backend = "setuptools.build_meta"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = -ra
+markers =
+    smoke: Marks smoke tests that validate core functionality.
+    e2e: Marks end-to-end scenarios that exercise multiple workflows.
+    projects: Tests interacting with XNAT project resources.

--- a/src/xnat_selenium/__init__.py
+++ b/src/xnat_selenium/__init__.py
@@ -1,0 +1,4 @@
+"""Public exports for the XNAT Selenium test helpers."""
+from .config import XnatConfig
+
+__all__ = ["XnatConfig"]

--- a/src/xnat_selenium/config.py
+++ b/src/xnat_selenium/config.py
@@ -1,0 +1,36 @@
+"""Configuration helpers for the XNAT Selenium test-suite."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class XnatConfig:
+    """Container for runtime configuration values."""
+
+    base_url: str
+    username: str
+    password: str
+    headless: bool = True
+
+    @classmethod
+    def from_env(cls, *, base_url: str | None = None, username: str | None = None, password: str | None = None, headless: bool | None = None) -> "XnatConfig":
+        resolved_base_url = base_url or os.getenv("XNAT_BASE_URL")
+        resolved_username = username or os.getenv("XNAT_USERNAME")
+        resolved_password = password or os.getenv("XNAT_PASSWORD")
+        resolved_headless = headless if headless is not None else os.getenv("XNAT_HEADLESS", "1") not in {"0", "false", "False"}
+
+        if not resolved_base_url:
+            raise ValueError("XNAT base URL must be provided via --base-url or XNAT_BASE_URL")
+        if not resolved_username:
+            raise ValueError("XNAT username must be provided via --username or XNAT_USERNAME")
+        if resolved_password is None:
+            raise ValueError("XNAT password must be provided via --password or XNAT_PASSWORD")
+
+        return cls(
+            base_url=resolved_base_url.rstrip("/"),
+            username=resolved_username,
+            password=resolved_password,
+            headless=resolved_headless,
+        )

--- a/src/xnat_selenium/pages/base.py
+++ b/src/xnat_selenium/pages/base.py
@@ -1,0 +1,111 @@
+"""Shared helpers for interacting with XNAT pages via Selenium.
+
+This module provides a small convenience wrapper around ``WebDriver`` to make
+explicit waits, navigation, and logging consistent across the page objects used
+in the test-suite.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Iterable, Optional, Tuple
+
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+Locator = Tuple[str, str]
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BasePage:
+    """Base implementation for all XNAT page objects.
+
+    Parameters
+    ----------
+    driver:
+        The Selenium ``WebDriver`` instance used for the current test run.
+    base_url:
+        The base URL of the XNAT deployment under test.
+    timeout:
+        Default explicit wait timeout, in seconds.
+    """
+
+    def __init__(self, driver: WebDriver, base_url: str, timeout: int = 20) -> None:
+        self.driver = driver
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    # Navigation helpers
+    # ------------------------------------------------------------------
+    def visit(self, path: str) -> None:
+        """Navigate to a path relative to ``base_url``."""
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        LOGGER.debug("Navigating to %s", url)
+        self.driver.get(url)
+
+    # ------------------------------------------------------------------
+    # Waiting helpers
+    # ------------------------------------------------------------------
+    def wait_for_visibility(self, locator: Locator, timeout: Optional[int] = None):
+        """Wait until an element located by ``locator`` is visible."""
+        LOGGER.debug("Waiting for visibility of %s", locator)
+        wait = WebDriverWait(self.driver, timeout or self.timeout)
+        return wait.until(EC.visibility_of_element_located(locator))
+
+    def wait_for_clickable(self, locator: Locator, timeout: Optional[int] = None):
+        """Wait until an element located by ``locator`` can be clicked."""
+        LOGGER.debug("Waiting for clickability of %s", locator)
+        wait = WebDriverWait(self.driver, timeout or self.timeout)
+        return wait.until(EC.element_to_be_clickable(locator))
+
+    def wait_until(self, condition: Callable[[WebDriver], bool], *, timeout: Optional[int] = None, message: str = "") -> None:
+        """Wait until a custom ``condition`` returns ``True``."""
+        LOGGER.debug("Waiting until condition %s", message or condition)
+        wait = WebDriverWait(self.driver, timeout or self.timeout)
+        try:
+            wait.until(condition, message)
+        except TimeoutException as exc:  # pragma: no cover - defensive logging
+            LOGGER.error("Timeout while waiting for condition %s: %s", message, exc)
+            raise
+
+    # ------------------------------------------------------------------
+    # Element interaction helpers
+    # ------------------------------------------------------------------
+    def click(self, locator: Locator) -> None:
+        element = self.wait_for_clickable(locator)
+        LOGGER.debug("Clicking element %s", locator)
+        element.click()
+
+    def fill(self, locator: Locator, value: str, *, clear: bool = True) -> None:
+        element = self.wait_for_visibility(locator)
+        LOGGER.debug("Typing in element %s", locator)
+        if clear:
+            element.clear()
+        element.send_keys(value)
+
+    def text_of(self, locator: Locator) -> str:
+        element = self.wait_for_visibility(locator)
+        text = element.text.strip()
+        LOGGER.debug("Text of %s: %s", locator, text)
+        return text
+
+    def elements(self, locator: Locator):
+        LOGGER.debug("Finding elements %s", locator)
+        return self.driver.find_elements(*locator)
+
+    def any_visible(self, locators: Iterable[Locator], timeout: Optional[int] = None) -> Locator:
+        """Wait until any of the provided locators is visible.
+
+        The locator that first becomes visible is returned.
+        """
+        wait = WebDriverWait(self.driver, timeout or self.timeout)
+        for locator in locators:
+            try:
+                wait.until(EC.visibility_of_element_located(locator))
+                return locator
+            except TimeoutException:
+                continue
+        raise TimeoutException("None of the provided locators became visible")

--- a/src/xnat_selenium/pages/dashboard.py
+++ b/src/xnat_selenium/pages/dashboard.py
@@ -1,0 +1,31 @@
+"""Page objects that model the main XNAT dashboard after login."""
+from __future__ import annotations
+
+from selenium.webdriver.common.by import By
+
+from .base import BasePage
+
+
+class DashboardPage(BasePage):
+    """Landing page once a user authenticates to XNAT."""
+
+    path = "/app/template/XDATScreen_select_project.vm"
+
+    _welcome_banner = (By.CSS_SELECTOR, "#page-content h1, .welcome-message")
+    _projects_link = (By.CSS_SELECTOR, "a[href*='projects'], a[href*='SelectProject']")
+    _user_menu = (By.CSS_SELECTOR, "#user-box, .user-menu")
+    _logout_link = (By.CSS_SELECTOR, "a[href*='Logout']")
+
+    def wait_until_loaded(self) -> None:
+        self.wait_for_visibility(self._welcome_banner)
+
+    def go_to_projects(self) -> None:
+        self.click(self._projects_link)
+
+    def welcome_message(self) -> str:
+        """Return the welcome banner text displayed on the dashboard."""
+        return self.text_of(self._welcome_banner)
+
+    def logout(self) -> None:
+        self.click(self._user_menu)
+        self.click(self._logout_link)

--- a/src/xnat_selenium/pages/experiments.py
+++ b/src/xnat_selenium/pages/experiments.py
@@ -1,0 +1,45 @@
+"""Page object helpers for managing imaging sessions (experiments)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from selenium.webdriver.common.by import By
+
+from .base import BasePage
+
+
+@dataclass
+class Experiment:
+    """Representation of an XNAT experiment (imaging session)."""
+
+    label: str
+    modality: Optional[str] = None
+
+
+class ExperimentsPage(BasePage):
+    """Interact with experiments for a given subject."""
+
+    _add_experiment_button = (By.CSS_SELECTOR, "a[href*='AddExperiment'], button#create-session")
+    _experiment_label = (By.NAME, "label")
+    _experiment_modality = (By.NAME, "modality")
+    _save_button = (By.CSS_SELECTOR, "form button[type='submit'], form input[type='submit']")
+    _experiment_table_rows = (By.CSS_SELECTOR, "table.experiment-list tbody tr")
+
+    def open(self, project_identifier: str, subject_label: str) -> None:
+        self.visit(
+            f"/app/action/DisplayItemAction/search_element/experiment/search_field/PROJECT/search_value/{project_identifier}?subject={subject_label}"
+        )
+        self.wait_for_visibility(self._add_experiment_button)
+
+    def add_experiment(self, experiment: Experiment) -> None:
+        self.click(self._add_experiment_button)
+        self.wait_for_visibility(self._experiment_label)
+        self.fill(self._experiment_label, experiment.label)
+        if experiment.modality:
+            self.fill(self._experiment_modality, experiment.modality)
+        self.click(self._save_button)
+
+    def experiment_exists(self, experiment: Experiment) -> bool:
+        rows = self.elements(self._experiment_table_rows)
+        return any(experiment.label in row.text for row in rows)

--- a/src/xnat_selenium/pages/login.py
+++ b/src/xnat_selenium/pages/login.py
@@ -1,0 +1,31 @@
+"""Page object modelling the XNAT login screen."""
+from __future__ import annotations
+
+from selenium.webdriver.common.by import By
+
+from .base import BasePage
+
+
+class LoginPage(BasePage):
+    """Interact with the XNAT login page."""
+
+    # The login view can be reached via ``/`` or ``/app/template/Login.vm``.
+    path = "/app/template/Login.vm"
+
+    _username_input = (By.NAME, "login")
+    _password_input = (By.NAME, "password")
+    _submit_button = (By.CSS_SELECTOR, "form button[type='submit'], form input[type='submit']")
+    _error_banner = (By.CSS_SELECTOR, ".alert-error, .message-error, .error")
+
+    def open(self) -> "LoginPage":
+        self.visit(self.path)
+        self.wait_for_visibility(self._username_input)
+        return self
+
+    def login(self, username: str, password: str) -> None:
+        self.fill(self._username_input, username)
+        self.fill(self._password_input, password)
+        self.click(self._submit_button)
+
+    def error_message(self) -> str:
+        return self.text_of(self._error_banner)

--- a/src/xnat_selenium/pages/projects.py
+++ b/src/xnat_selenium/pages/projects.py
@@ -1,0 +1,57 @@
+"""Page objects related to project management in XNAT."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from selenium.webdriver.common.by import By
+
+from .base import BasePage
+
+
+@dataclass
+class Project:
+    """Simple representation of an XNAT project used in tests."""
+
+    identifier: str
+    name: str
+    description: Optional[str] = None
+
+
+class ProjectsPage(BasePage):
+    """Interact with the project listing and creation screens."""
+
+    path = "/app/template/XDATScreen_manage_projects.vm"
+
+    _create_button = (By.CSS_SELECTOR, "a#create-project, a[href*='CreateProject']")
+    _project_identifier = (By.NAME, "ID")
+    _project_name = (By.NAME, "name")
+    _project_description = (By.NAME, "description")
+    _save_button = (By.CSS_SELECTOR, "form button[type='submit'], form input[type='submit']")
+    _project_table_rows = (By.CSS_SELECTOR, "table.project-list tbody tr")
+    _project_row_link = "a[href*='projectID=%s']"
+
+    def open(self) -> "ProjectsPage":
+        self.visit(self.path)
+        self.wait_for_visibility(self._create_button)
+        return self
+
+    def start_project_creation(self) -> None:
+        self.click(self._create_button)
+        self.wait_for_visibility(self._project_identifier)
+
+    def create_project(self, project: Project) -> None:
+        self.start_project_creation()
+        self.fill(self._project_identifier, project.identifier)
+        self.fill(self._project_name, project.name)
+        if project.description:
+            self.fill(self._project_description, project.description)
+        self.click(self._save_button)
+
+    def project_exists(self, project: Project) -> bool:
+        rows = self.elements(self._project_table_rows)
+        return any(project.identifier in row.text for row in rows)
+
+    def open_project(self, project: Project) -> None:
+        link = (By.CSS_SELECTOR, self._project_row_link % project.identifier)
+        self.click(link)

--- a/src/xnat_selenium/pages/subjects.py
+++ b/src/xnat_selenium/pages/subjects.py
@@ -1,0 +1,43 @@
+"""Page object helpers for managing subjects within a project."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from selenium.webdriver.common.by import By
+
+from .base import BasePage
+
+
+@dataclass
+class Subject:
+    """Representation of an XNAT subject used in tests."""
+
+    label: str
+    species: Optional[str] = None
+
+
+class SubjectsPage(BasePage):
+    """Interact with the subject list within a project."""
+
+    _add_subject_button = (By.CSS_SELECTOR, "a[href*='AddSubject'], button#create-subject")
+    _subject_label = (By.NAME, "label")
+    _subject_species = (By.NAME, "species")
+    _save_subject = (By.CSS_SELECTOR, "form button[type='submit'], form input[type='submit']")
+    _subject_table_rows = (By.CSS_SELECTOR, "table.subject-list tbody tr")
+
+    def open(self, project_identifier: str) -> None:
+        self.visit(f"/app/action/DisplayItemAction/search_element/subject/search_field/PROJECT/search_value/{project_identifier}")
+        self.wait_for_visibility(self._add_subject_button)
+
+    def add_subject(self, subject: Subject) -> None:
+        self.click(self._add_subject_button)
+        self.wait_for_visibility(self._subject_label)
+        self.fill(self._subject_label, subject.label)
+        if subject.species:
+            self.fill(self._subject_species, subject.species)
+        self.click(self._save_subject)
+
+    def subject_exists(self, subject: Subject) -> bool:
+        rows = self.elements(self._subject_table_rows)
+        return any(subject.label in row.text for row in rows)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,101 @@
+"""Pytest configuration and shared fixtures for the XNAT Selenium suite."""
+from __future__ import annotations
+
+import os
+from typing import Generator
+
+import pytest
+from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.edge.options import Options as EdgeOptions
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
+
+from xnat_selenium.config import XnatConfig
+from xnat_selenium.pages.dashboard import DashboardPage
+from xnat_selenium.pages.login import LoginPage
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("xnat")
+    group.addoption("--base-url", action="store", dest="base_url", help="Base URL of the XNAT instance")
+    group.addoption("--username", action="store", dest="username", help="XNAT username to authenticate with")
+    group.addoption("--password", action="store", dest="password", help="XNAT password to authenticate with")
+    group.addoption("--browser", action="store", dest="browser", default="chrome", help="Browser to use (chrome|firefox|edge)")
+    group.addoption("--remote-url", action="store", dest="remote_url", help="URL of a remote Selenium server")
+    group.addoption("--headed", action="store_true", dest="headed", help="Run browsers in headed mode")
+
+
+@pytest.fixture(scope="session")
+def xnat_config(pytestconfig: pytest.Config) -> XnatConfig:
+    try:
+        return XnatConfig.from_env(
+            base_url=pytestconfig.getoption("base_url"),
+            username=pytestconfig.getoption("username"),
+            password=pytestconfig.getoption("password"),
+            headless=not pytestconfig.getoption("headed"),
+        )
+    except ValueError as exc:
+        pytest.skip(str(exc))
+
+
+def _build_driver(browser: str, *, headless: bool, remote_url: str | None) -> webdriver.Remote:
+    browser = browser.lower()
+    if browser == "chrome":
+        options = ChromeOptions()
+        if headless:
+            options.add_argument("--headless=new")
+        options.add_argument("--disable-gpu")
+        options.add_argument("--window-size=1920,1080")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        if remote_url:
+            return webdriver.Remote(command_executor=remote_url, options=options)
+        return webdriver.Chrome(options=options)
+    if browser == "firefox":
+        options = FirefoxOptions()
+        options.set_preference("dom.webnotifications.enabled", False)
+        options.set_preference("media.navigator.streams.fake", True)
+        options.headless = headless
+        if remote_url:
+            return webdriver.Remote(command_executor=remote_url, options=options)
+        return webdriver.Firefox(options=options)
+    if browser == "edge":
+        options = EdgeOptions()
+        if headless:
+            options.add_argument("--headless=new")
+        options.add_argument("--window-size=1920,1080")
+        if remote_url:
+            return webdriver.Remote(command_executor=remote_url, options=options)
+        return webdriver.Edge(options=options)
+    raise pytest.UsageError(f"Unsupported browser '{browser}'. Use chrome, firefox, or edge.")
+
+
+@pytest.fixture(scope="session")
+def driver(pytestconfig: pytest.Config, xnat_config: XnatConfig) -> Generator[webdriver.Remote, None, None]:
+    remote_url = pytestconfig.getoption("remote_url") or os.getenv("SELENIUM_REMOTE_URL")
+    try:
+        driver_instance = _build_driver(
+            pytestconfig.getoption("browser"), headless=xnat_config.headless, remote_url=remote_url
+        )
+    except WebDriverException as exc:  # pragma: no cover - exercised at runtime
+        pytest.skip(f"Unable to start Selenium driver: {exc}")
+    driver_instance.set_page_load_timeout(60)
+    driver_instance.implicitly_wait(2)
+    yield driver_instance
+    driver_instance.quit()
+
+
+@pytest.fixture
+def dashboard(driver: webdriver.Remote, xnat_config: XnatConfig) -> Generator[DashboardPage, None, None]:
+    login_page = LoginPage(driver, xnat_config.base_url).open()
+    login_page.login(xnat_config.username, xnat_config.password)
+    dashboard_page = DashboardPage(driver, xnat_config.base_url)
+    dashboard_page.wait_until_loaded()
+    try:
+        yield dashboard_page
+    finally:
+        try:
+            dashboard_page.logout()
+        except Exception:  # pragma: no cover - best effort logout
+            pass

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,34 @@
+"""Authentication focused tests."""
+from __future__ import annotations
+
+import pytest
+
+from xnat_selenium.pages.dashboard import DashboardPage
+from xnat_selenium.pages.login import LoginPage
+
+
+@pytest.mark.smoke
+def test_successful_login(driver, xnat_config):
+    """Users with valid credentials should land on the dashboard."""
+    login_page = LoginPage(driver, xnat_config.base_url).open()
+    login_page.login(xnat_config.username, xnat_config.password)
+
+    dashboard = DashboardPage(driver, xnat_config.base_url)
+    dashboard.wait_until_loaded()
+    assert dashboard.welcome_message()
+    dashboard.logout()
+
+
+@pytest.mark.parametrize(
+    "username,password",
+    [
+        ("", ""),
+        ("invalid", "credentials"),
+    ],
+)
+def test_login_failure(driver, xnat_config, username, password):
+    """Invalid credentials should display an error message."""
+    login_page = LoginPage(driver, xnat_config.base_url).open()
+    login_page.login(username or xnat_config.username, password)
+
+    assert login_page.error_message()

--- a/tests/test_project_lifecycle.py
+++ b/tests/test_project_lifecycle.py
@@ -1,0 +1,51 @@
+"""End-to-end project lifecycle coverage."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from xnat_selenium.pages.dashboard import DashboardPage
+from xnat_selenium.pages.experiments import Experiment, ExperimentsPage
+from xnat_selenium.pages.login import LoginPage
+from xnat_selenium.pages.projects import Project, ProjectsPage
+from xnat_selenium.pages.subjects import Subject, SubjectsPage
+
+
+@pytest.mark.e2e
+@pytest.mark.projects
+def test_project_subject_and_experiment_creation(driver, xnat_config):
+    """Create a project, add a subject, and register an experiment."""
+    identifier = f"AUTO{uuid.uuid4().hex[:6]}"
+    project = Project(identifier=identifier, name=f"Automated Project {identifier}", description="Created by Selenium tests")
+    subject = Subject(label=f"SUBJ-{uuid.uuid4().hex[:6]}")
+    experiment = Experiment(label=f"EXP-{uuid.uuid4().hex[:6]}")
+
+    login_page = LoginPage(driver, xnat_config.base_url).open()
+    login_page.login(xnat_config.username, xnat_config.password)
+    dashboard = DashboardPage(driver, xnat_config.base_url)
+    dashboard.wait_until_loaded()
+
+    try:
+        dashboard.go_to_projects()
+
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        projects_page.create_project(project)
+
+        projects_page.open()
+        projects_page.wait_until(lambda drv: projects_page.project_exists(project), message="project to appear in table")
+
+        subjects_page = SubjectsPage(driver, xnat_config.base_url)
+        subjects_page.open(project.identifier)
+        subjects_page.add_subject(subject)
+        subjects_page.wait_until(lambda drv: subjects_page.subject_exists(subject), message="subject to appear in table")
+
+        experiments_page = ExperimentsPage(driver, xnat_config.base_url)
+        experiments_page.open(project.identifier, subject.label)
+        experiments_page.add_experiment(experiment)
+        experiments_page.wait_until(
+            lambda drv: experiments_page.experiment_exists(experiment), message="experiment to appear in table"
+        )
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()


### PR DESCRIPTION
## Summary
- add reusable Selenium page objects for key XNAT workflows
- introduce pytest fixtures and tests that cover login and project lifecycle flows
- document setup, configuration, and dependency requirements for running the suite

## Testing
- `pytest --collect-only` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68e1b7098e0883219e87bd3764b51b4a