### PR TITLE
Add helper for local XNAT docker compose test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local test environment assets
+.xnat-test-env/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,41 @@ headless mode without installing dependencies locally.
    docker run --rm -it --entrypoint /bin/bash xnat-selenium-tests
    ```
 
+## Local XNAT test environment
+
+Spin up a disposable XNAT instance using the
+[xnat-docker-compose](https://github.com/NrgXnat/xnat-docker-compose) project.
+The helper script in `scripts/manage_xnat_test_env.sh` will clone or update that
+repository inside `.xnat-test-env/` and proxy common Docker Compose commands.
+
+1. Ensure Docker and Docker Compose are installed locally.
+2. Start the stack:
+
+   ```bash
+   ./scripts/manage_xnat_test_env.sh up
+   ```
+
+   The services will be accessible on `http://localhost:8080` with the default
+   credentials `admin` / `admin` once the containers finish booting.
+3. Point the Selenium tests at the local instance:
+
+   ```bash
+   export XNAT_BASE_URL=http://localhost:8080
+   export XNAT_USERNAME=admin
+   export XNAT_PASSWORD=admin
+   pytest -m smoke
+   ```
+
+4. When finished, stop or tear down the environment:
+
+   ```bash
+   ./scripts/manage_xnat_test_env.sh down    # stop containers
+   ./scripts/manage_xnat_test_env.sh reset   # stop and remove volumes
+   ```
+
+Refer to the upstream repository for environment customization options such as
+port overrides or data persistence tweaks.
+
 ## Project structure
 
 ```

--- a/scripts/manage_xnat_test_env.sh
+++ b/scripts/manage_xnat_test_env.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL=${XNAT_COMPOSE_REPO:-https://github.com/NrgXnat/xnat-docker-compose.git}
+TARGET_DIR=${XNAT_COMPOSE_DIR:-.xnat-test-env}
+
+usage() {
+    cat <<USAGE
+Usage: $0 <command>
+
+Commands:
+  init       Clone or update the xnat-docker-compose repository locally
+  up         Start the XNAT test stack with docker compose (implies init)
+  down       Stop the stack and remove containers (implies init)
+  reset      Remove the stack and persistent volumes (implies init)
+  status     Show stack status via docker compose ps (implies init)
+  help       Show this message
+
+Environment variables:
+  XNAT_COMPOSE_REPO  Override the git repository URL. Defaults to
+                     https://github.com/NrgXnat/xnat-docker-compose.git
+  XNAT_COMPOSE_DIR   Directory where the repository is cloned.
+                     Defaults to .xnat-test-env
+USAGE
+}
+
+ensure_repo() {
+    if [ ! -d "$TARGET_DIR/.git" ]; then
+        echo "Cloning XNAT docker compose repo into $TARGET_DIR"
+        git clone "$REPO_URL" "$TARGET_DIR"
+    else
+        echo "Updating existing repository in $TARGET_DIR"
+        git -C "$TARGET_DIR" pull --ff-only
+    fi
+}
+
+cmd=${1:-help}
+case "$cmd" in
+    init)
+        ensure_repo
+        ;;
+    up)
+        ensure_repo
+        (cd "$TARGET_DIR" && docker compose up -d)
+        ;;
+    down)
+        ensure_repo
+        (cd "$TARGET_DIR" && docker compose down)
+        ;;
+    reset)
+        ensure_repo
+        (cd "$TARGET_DIR" && docker compose down -v)
+        ;;
+    status)
+        ensure_repo
+        (cd "$TARGET_DIR" && docker compose ps)
+        ;;
+    help|--help|-h)
+        usage
+        ;;
+    *)
+        echo "Unknown command: $cmd" >&2
+        echo
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- add a helper script that clones and manages the xnat-docker-compose stack for tests
- document how to run the Selenium suite against the local dockerised XNAT instance
- ignore the working directory created for the docker compose repository

## Testing
- not run (infrastructure only)


------
https://chatgpt.com/codex/tasks/task_e_68e1c0c6c86483219a860444049bd713