### PR TITLE
Port Bitbucket support utilities and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pytest>=7.4",
     "selenium>=4.13",
+    "pyyaml>=6.0",
 ]
 
 [build-system]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ markers =
     smoke: Marks smoke tests that validate core functionality.
     e2e: Marks end-to-end scenarios that exercise multiple workflows.
     projects: Tests interacting with XNAT project resources.
+    subjects: Tests that manage subject records within a project.
+    experiments: Tests that manage experiment/imaging session records.

--- a/src/xnat_selenium/browser.py
+++ b/src/xnat_selenium/browser.py
@@ -1,0 +1,53 @@
+"""Minimal browser support registry mirroring the legacy suite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Dict, Type
+
+
+@dataclass(frozen=True)
+class BaseBrowserSupport:
+    """Base class for browser-specific capabilities."""
+
+    name: ClassVar[str] = ""
+
+
+class ChromeSupport(BaseBrowserSupport):
+    name = "Chrome"
+
+
+class FirefoxSupport(BaseBrowserSupport):
+    name = "MozillaFirefox"
+
+
+class BrowserSupport:
+    """Cache for browser support helpers used by the selenium suite."""
+
+    _ALIASES: ClassVar[Dict[str, Type[BaseBrowserSupport]]] = {
+        "chrome": ChromeSupport,
+        "google chrome": ChromeSupport,
+        "mozilla firefox": FirefoxSupport,
+        "firefox": FirefoxSupport,
+        "ff": FirefoxSupport,
+    }
+    cached_browser_support: ClassVar[Type[BaseBrowserSupport] | None] = None
+
+    @classmethod
+    def cache_browser(cls, browser_key: str) -> None:
+        """Cache the browser support class for ``browser_key``."""
+
+        normalized = browser_key.strip().lower()
+        support_cls = cls._ALIASES.get(normalized)
+        if support_cls is None:
+            known = sorted({support.name for support in cls._ALIASES.values()})
+            options = ", ".join(known)
+            raise RuntimeError(
+                f"Unknown browser: {browser_key}. Available browser helpers: {options}"
+            )
+        cls.cached_browser_support = support_cls
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        cls.cached_browser_support = None
+

--- a/src/xnat_selenium/element_specifications.py
+++ b/src/xnat_selenium/element_specifications.py
@@ -1,0 +1,202 @@
+"""Utilities for marshalling element specifications from the legacy suite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, List, Mapping, Sequence
+
+import yaml
+
+
+class _ElementSpecLoader(yaml.SafeLoader):
+    pass
+
+
+def _text_index_array_constructor(loader: yaml.Loader, node: yaml.Node) -> Any:
+    mapping = loader.construct_mapping(node)
+    mapping["type"] = "textIndexArray"
+    return mapping
+
+
+_ElementSpecLoader.add_constructor("!textIndexArray", _text_index_array_constructor)
+_ElementSpecLoader.add_constructor("!<textIndexArray>", _text_index_array_constructor)
+_ElementSpecLoader.add_constructor("textIndexArray", _text_index_array_constructor)
+
+
+def _is_numeric(value: Any) -> bool:
+    if isinstance(value, (int, float, Decimal)):
+        return True
+    if isinstance(value, str):
+        try:
+            Decimal(value)
+        except Exception:
+            return False
+        return True
+    return False
+
+
+def _to_decimal(value: Any) -> Any:
+    if _is_numeric(value):
+        return Decimal(str(value))
+    return value
+
+
+@dataclass(frozen=True)
+class Locator:
+    type: str
+    value: str
+
+    @classmethod
+    def from_yaml(cls, payload: Any) -> "Locator":
+        if isinstance(payload, str):
+            return cls(type="xpath", value=payload)
+        if isinstance(payload, Mapping):
+            locator_type = payload.get("type", "xpath")
+            value = payload.get("value")
+            if value is None:
+                raise ValueError("Locator payload missing 'value'")
+            return cls(type=str(locator_type), value=str(value))
+        raise TypeError(f"Unsupported locator payload: {payload!r}")
+
+    def to_yaml(self) -> Any:
+        if self.type.lower() == "xpath":
+            return self.value
+        return {"type": self.type, "value": self.value}
+
+
+@dataclass(frozen=True)
+class Element:
+    locator: Locator
+    value: Any
+
+    @classmethod
+    def from_yaml(cls, payload: Mapping[str, Any]) -> "Element":
+        locator = Locator.from_yaml(payload["locator"])
+        value = _to_decimal(payload["value"])
+        return cls(locator=locator, value=value)
+
+    def formatted_value(self) -> str:
+        if isinstance(self.value, Decimal):
+            return format(self.value, "f")
+        return str(self.value)
+
+    def to_yaml(self) -> Mapping[str, Any]:
+        return {"locator": self.locator.to_yaml(), "value": self.value}
+
+
+class Comparator:
+    def to_yaml_blocks(self) -> List[str]:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class EqualityElementComparator(Comparator):
+    elements: Sequence[Element] = field(default_factory=list)
+
+    def to_yaml_blocks(self) -> List[str]:
+        lines = ["- type: Equals", "  elements:"]
+        for element in self.elements:
+            locator = element.locator.to_yaml()
+            if isinstance(locator, str):
+                lines.append(f"  - locator: \"{locator}\"")
+            else:
+                lines.append("  - locator:")
+                lines.append(f"      type: {locator['type']}")
+                lines.append(f"      value: {locator['value']}")
+            lines.append(f"    value: {element.formatted_value()}")
+        return lines
+
+
+@dataclass(frozen=True)
+class MaxPercentToleranceElementComparator(Comparator):
+    tolerance: Decimal
+    elements: Sequence[Element] = field(default_factory=list)
+
+    def to_yaml_blocks(self) -> List[str]:
+        lines = ["- type: maxPercentTolerance", f"  percent: {format(self.tolerance, 'f')}", "  elements:"]
+        for element in self.elements:
+            locator = element.locator.to_yaml()
+            if isinstance(locator, str):
+                lines.append(f"  - locator: \"{locator}\"")
+            else:
+                lines.append("  - locator:")
+                lines.append(f"      type: {locator['type']}")
+                lines.append(f"      value: {locator['value']}")
+            lines.append(f"    value: {element.formatted_value()}")
+        return lines
+
+
+@dataclass(frozen=True)
+class TextIndexArray:
+    id: str
+    locator: str
+    offset: int
+    type: str = "textIndexArray"
+
+    @classmethod
+    def from_yaml(cls, payload: Mapping[str, Any]) -> "TextIndexArray":
+        return cls(
+            id=str(payload["id"]),
+            locator=str(payload["locator"]),
+            offset=int(payload["offset"]),
+        )
+
+    def to_yaml_blocks(self) -> List[str]:
+        return [
+            f"- !<{self.type}>",
+            f"  id: {self.id}",
+            f"  locator: \"{self.locator}\"",
+            f"  offset: {self.offset}",
+        ]
+
+
+@dataclass(frozen=True)
+class ElementSpecifications:
+    comparators: Sequence[Comparator]
+    locator_caches: Sequence[TextIndexArray]
+    locator_replacements: Mapping[str, str]
+
+    @classmethod
+    def from_yaml(cls, payload: str) -> "ElementSpecifications":
+        data = yaml.load(payload, Loader=_ElementSpecLoader)
+        comparators = []
+        for comparator_payload in data.get("comparators", []):
+            comparator_type = comparator_payload.get("type")
+            elements = [
+                Element.from_yaml(element_payload)
+                for element_payload in comparator_payload.get("elements", [])
+            ]
+            if comparator_type == "Equals":
+                comparators.append(EqualityElementComparator(tuple(elements)))
+            elif comparator_type == "maxPercentTolerance":
+                tolerance = Decimal(str(comparator_payload.get("percent", 0)))
+                comparators.append(
+                    MaxPercentToleranceElementComparator(tolerance, tuple(elements))
+                )
+            else:
+                raise ValueError(f"Unsupported comparator type: {comparator_type}")
+
+        locator_caches = [
+            TextIndexArray.from_yaml(cache_payload)
+            for cache_payload in data.get("locatorCaches", [])
+        ]
+        locator_replacements = data.get("locatorReplacements", {})
+        return cls(
+            comparators=tuple(comparators),
+            locator_caches=tuple(locator_caches),
+            locator_replacements=dict(locator_replacements),
+        )
+
+    def to_yaml(self) -> str:
+        lines: List[str] = ["comparators:"]
+        for comparator in self.comparators:
+            lines.extend(comparator.to_yaml_blocks())
+        lines.append("locatorCaches:")
+        for cache in self.locator_caches:
+            lines.extend(cache.to_yaml_blocks())
+        lines.append("locatorReplacements:")
+        for key, value in self.locator_replacements.items():
+            lines.append(f"  {key}: \"{value}\"")
+        return "\n".join(lines) + "\n"
+

--- a/src/xnat_selenium/mock_driver.py
+++ b/src/xnat_selenium/mock_driver.py
@@ -40,6 +40,8 @@ class _Project:
     identifier: str
     name: str
     description: str | None = None
+    aliases: tuple[str, ...] = ()
+    keywords: tuple[str, ...] = ()
 
 
 @dataclass
@@ -253,7 +255,16 @@ class MockWebDriver:
             return [
                 MockWebElement(
                     locator=locator,
-                    text_getter=lambda proj=proj: f"{proj.identifier} {proj.name}",
+                    text_getter=lambda proj=proj: " | ".join(
+                        filter(
+                            None,
+                            [
+                                proj.identifier,
+                                proj.name,
+                                proj.description,
+                            ],
+                        )
+                    ),
                 )
                 for proj in self._projects
             ]
@@ -261,14 +272,36 @@ class MockWebDriver:
             project_identifier = self._ui.current_project
             subjects = self._subjects.get(project_identifier or "", [])
             return [
-                MockWebElement(locator=locator, text_getter=lambda subj=subj: subj.label)
+                MockWebElement(
+                    locator=locator,
+                    text_getter=lambda subj=subj: " | ".join(
+                        filter(
+                            None,
+                            [
+                                subj.label,
+                                subj.species,
+                            ],
+                        )
+                    ),
+                )
                 for subj in subjects
             ]
         if page == "experiments" and locator == (By.CSS_SELECTOR, "table.experiment-list tbody tr"):
             key = (self._ui.current_project or "", self._ui.current_subject or "")
             experiments = self._experiments.get(key, [])
             return [
-                MockWebElement(locator=locator, text_getter=lambda exp=exp: exp.label)
+                MockWebElement(
+                    locator=locator,
+                    text_getter=lambda exp=exp: " | ".join(
+                        filter(
+                            None,
+                            [
+                                exp.label,
+                                exp.modality,
+                            ],
+                        )
+                    ),
+                )
                 for exp in experiments
             ]
         return []
@@ -462,6 +495,8 @@ class MockWebDriver:
             identifier=self._ui.project_identifier,
             name=self._ui.project_name,
             description=self._ui.project_description or None,
+            aliases=(),
+            keywords=(),
         )
         # prevent duplicate identifiers from creating multiple entries
         self._projects = [p for p in self._projects if p.identifier != project.identifier]

--- a/src/xnat_selenium/page_registry.py
+++ b/src/xnat_selenium/page_registry.py
@@ -1,0 +1,107 @@
+"""Version-aware page object registry inspired by the Bitbucket suite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple, Type
+
+
+class XnatPageComponent:
+    """Base class for page components bound to XNAT versions."""
+
+    handled_versions: Sequence[Type["XnatVersion"]] = ()
+
+    @classmethod
+    def get_handled_versions(cls) -> Tuple[Type["XnatVersion"], ...]:
+        return tuple(cls.handled_versions)
+
+
+class XnatVersion:
+    """Marker base class for XNAT versions."""
+
+
+class PageObjectRegistry:
+    """Registry mapping base components to version specific subclasses."""
+
+    _registry: Dict[Type[XnatPageComponent], List[Type[XnatPageComponent]]] = {}
+
+    @classmethod
+    def register(cls, component: Type[XnatPageComponent]) -> Type[XnatPageComponent]:
+        root = cls._root_component(component)
+        cls._registry.setdefault(root, [])
+        if component not in cls._registry[root]:
+            cls._registry[root].append(component)
+        return component
+
+    @classmethod
+    def clear(cls) -> None:
+        cls._registry.clear()
+
+    @classmethod
+    def get_page_object(
+        cls, base_component: Type[XnatPageComponent], version: Type["XnatVersion"]
+    ) -> Type[XnatPageComponent]:
+        root = cls._root_component(base_component)
+        candidates = cls._registry.get(root, [])
+        # Prefer most derived classes first
+        ordered = sorted(
+            candidates,
+            key=lambda component: (-cls._depth(component, root), -len(component.get_handled_versions())),
+        )
+        for component in ordered:
+            if version in component.get_handled_versions():
+                return component
+        return base_component
+
+    @staticmethod
+    def _root_component(component: Type[XnatPageComponent]) -> Type[XnatPageComponent]:
+        root = component
+        for base in component.mro():
+            if issubclass(base, XnatPageComponent) and base is not XnatPageComponent:
+                root = base
+        return root
+
+    @staticmethod
+    def _depth(component: Type[XnatPageComponent], root: Type[XnatPageComponent]) -> int:
+        depth = 0
+        current = component
+        while current is not root and current is not XnatPageComponent:
+            current = current.__mro__[1]
+            depth += 1
+        return depth
+
+
+@dataclass
+class Xnat_1_7_7(XnatVersion):
+    pass
+
+
+@dataclass
+class Xnat_1_7_5_2(XnatVersion):
+    pass
+
+
+@dataclass
+class Xnat_1_7_5(XnatVersion):
+    pass
+
+
+@dataclass
+class Xnat_1_7_4(XnatVersion):
+    pass
+
+
+@dataclass
+class Xnat_1_7_3(XnatVersion):
+    pass
+
+
+@dataclass
+class Xnat_1_7_2(XnatVersion):
+    pass
+
+
+@dataclass
+class Xnat_1_6dev(XnatVersion):
+    pass
+

--- a/src/xnat_selenium/pages/experiments.py
+++ b/src/xnat_selenium/pages/experiments.py
@@ -32,14 +32,38 @@ class ExperimentsPage(BasePage):
         )
         self.wait_for_visibility(self._add_experiment_button)
 
-    def add_experiment(self, experiment: Experiment) -> None:
+    def start_experiment_creation(self) -> None:
         self.click(self._add_experiment_button)
         self.wait_for_visibility(self._experiment_label)
-        self.fill(self._experiment_label, experiment.label)
-        if experiment.modality:
-            self.fill(self._experiment_modality, experiment.modality)
+
+    def enter_experiment_details(
+        self, *, label: str | None = None, modality: str | None = None
+    ) -> None:
+        if label is not None:
+            self.fill(self._experiment_label, label)
+        if modality is not None:
+            self.fill(self._experiment_modality, modality)
+
+    def submit_experiment_form(self) -> None:
         self.click(self._save_button)
 
+    def add_experiment(self, experiment: Experiment) -> None:
+        self.start_experiment_creation()
+        self.enter_experiment_details(label=experiment.label, modality=experiment.modality)
+        self.submit_experiment_form()
+
     def experiment_exists(self, experiment: Experiment) -> bool:
-        rows = self.elements(self._experiment_table_rows)
-        return any(experiment.label in row.text for row in rows)
+        rows = self.experiment_rows()
+        if experiment.modality:
+            return any(experiment.label in row and experiment.modality in row for row in rows)
+        return any(experiment.label in row for row in rows)
+
+    def experiment_rows(self) -> list[str]:
+        """Return the raw text contents of the experiment table rows."""
+
+        return [row.text for row in self.elements(self._experiment_table_rows)]
+
+    def experiment_count(self) -> int:
+        """Return the number of experiments currently displayed."""
+
+        return len(self.elements(self._experiment_table_rows))

--- a/src/xnat_selenium/pages/login.py
+++ b/src/xnat_selenium/pages/login.py
@@ -1,6 +1,7 @@
 """Page object modelling the XNAT login screen."""
 from __future__ import annotations
 
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 
 from .base import BasePage
@@ -29,3 +30,12 @@ class LoginPage(BasePage):
 
     def error_message(self) -> str:
         return self.text_of(self._error_banner)
+
+    def is_displayed(self, *, timeout: int | None = None) -> bool:
+        """Return ``True`` when the login form is visible."""
+
+        try:
+            self.wait_for_visibility(self._username_input, timeout=timeout)
+            return True
+        except TimeoutException:
+            return False

--- a/src/xnat_selenium/pages/project_details.py
+++ b/src/xnat_selenium/pages/project_details.py
@@ -1,0 +1,80 @@
+"""Project details tab helpers inspired by the legacy Selenium suite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from .projects import Project
+
+
+@dataclass(frozen=True)
+class ProjectSnapshot:
+    """Lightweight container mirroring the fields shown on the details tab."""
+
+    identifier: str
+    description: str | None = None
+    aliases: Sequence[str] = ()
+    keywords: Sequence[str] = ()
+
+    @classmethod
+    def from_project(cls, project: Project) -> "ProjectSnapshot":
+        return cls(
+            identifier=project.identifier,
+            description=project.description,
+            aliases=project.aliases,
+            keywords=project.keywords,
+        )
+
+
+class ProjectDetailsTab:
+    """Default behaviour for recent XNAT versions."""
+
+    def escape_on_project_page(self, text: str) -> str:
+        return text
+
+    def expected_project_id_string(self, project: ProjectSnapshot | Project) -> str:
+        snapshot = self._snapshot(project)
+        alias_blob = " ".join(snapshot.aliases)
+        if alias_blob:
+            escaped = self.escape_on_project_page(alias_blob)
+            return f"{snapshot.identifier} Aka: {escaped}"
+        return snapshot.identifier
+
+    def render_description(self, project: ProjectSnapshot | Project) -> str | None:
+        snapshot = self._snapshot(project)
+        if snapshot.description is None:
+            return None
+        return self.escape_on_project_page(snapshot.description)
+
+    def render_keywords(self, project: ProjectSnapshot | Project) -> str:
+        snapshot = self._snapshot(project)
+        if not snapshot.keywords:
+            return ""
+        blob = " ".join(snapshot.keywords)
+        return self.escape_on_project_page(blob)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _snapshot(self, project: ProjectSnapshot | Project) -> ProjectSnapshot:
+        if isinstance(project, ProjectSnapshot):
+            return project
+        return ProjectSnapshot.from_project(project)
+
+
+class LegacyProjectDetailsTab(ProjectDetailsTab):
+    """Historic behaviour that performed HTML escaping on display."""
+
+    _ESCAPE_MAP = {
+        "&": "&amp",
+        "<": "&lt",
+        ">": "&gt",
+        "'": "&apos",
+    }
+
+    def escape_on_project_page(self, text: str) -> str:
+        escaped = text
+        for needle, replacement in self._ESCAPE_MAP.items():
+            escaped = escaped.replace(needle, replacement)
+        return escaped

--- a/src/xnat_selenium/pages/projects.py
+++ b/src/xnat_selenium/pages/projects.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 
 from .base import BasePage
@@ -16,6 +17,18 @@ class Project:
     identifier: str
     name: str
     description: Optional[str] = None
+    aliases: tuple[str, ...] = ()
+    keywords: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        # Normalise potentially mutable iterables passed by callers so that
+        # repeated access always yields immutable tuples.  The production XNAT
+        # UI stores aliases and keywords as lists, so allowing callers to pass
+        # either lists or tuples keeps the tests ergonomic.
+        if not isinstance(self.aliases, tuple):
+            self.aliases = tuple(self.aliases or ())
+        if not isinstance(self.keywords, tuple):
+            self.keywords = tuple(self.keywords or ())
 
 
 class ProjectsPage(BasePage):
@@ -36,21 +49,65 @@ class ProjectsPage(BasePage):
         self.wait_for_visibility(self._create_button)
         return self
 
+    def wait_until_loaded(self, *, timeout: int | None = None) -> None:
+        """Wait until the project listing has fully loaded."""
+
+        self.wait_for_visibility(self._create_button, timeout=timeout)
+
+    def is_loaded(self, *, timeout: int | None = None) -> bool:
+        """Return ``True`` when the project listing controls are visible."""
+
+        try:
+            self.wait_until_loaded(timeout=timeout)
+            return True
+        except TimeoutException:
+            return False
+
     def start_project_creation(self) -> None:
         self.click(self._create_button)
         self.wait_for_visibility(self._project_identifier)
 
-    def create_project(self, project: Project) -> None:
-        self.start_project_creation()
-        self.fill(self._project_identifier, project.identifier)
-        self.fill(self._project_name, project.name)
-        if project.description:
-            self.fill(self._project_description, project.description)
+    def enter_project_details(
+        self,
+        *,
+        identifier: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        """Populate the project creation form fields."""
+
+        if identifier is not None:
+            self.fill(self._project_identifier, identifier)
+        if name is not None:
+            self.fill(self._project_name, name)
+        if description is not None:
+            self.fill(self._project_description, description)
+
+    def submit_project_form(self) -> None:
+        """Submit the project creation form without additional validation."""
+
         self.click(self._save_button)
 
+    def create_project(self, project: Project) -> None:
+        self.start_project_creation()
+        self.enter_project_details(identifier=project.identifier, name=project.name, description=project.description)
+        self.submit_project_form()
+
     def project_exists(self, project: Project) -> bool:
-        rows = self.elements(self._project_table_rows)
-        return any(project.identifier in row.text for row in rows)
+        rows = self.project_rows()
+        if project.description:
+            return any(project.identifier in row and project.description in row for row in rows)
+        return any(project.identifier in row for row in rows)
+
+    def project_rows(self) -> list[str]:
+        """Return the raw text contents of the project table rows."""
+
+        return [row.text for row in self.elements(self._project_table_rows)]
+
+    def project_count(self) -> int:
+        """Return the number of projects currently displayed."""
+
+        return len(self.elements(self._project_table_rows))
 
     def open_project(self, project: Project) -> None:
         link = (By.CSS_SELECTOR, self._project_row_link % project.identifier)

--- a/src/xnat_selenium/pages/subjects.py
+++ b/src/xnat_selenium/pages/subjects.py
@@ -30,14 +30,36 @@ class SubjectsPage(BasePage):
         self.visit(f"/app/action/DisplayItemAction/search_element/subject/search_field/PROJECT/search_value/{project_identifier}")
         self.wait_for_visibility(self._add_subject_button)
 
-    def add_subject(self, subject: Subject) -> None:
+    def start_subject_creation(self) -> None:
         self.click(self._add_subject_button)
         self.wait_for_visibility(self._subject_label)
-        self.fill(self._subject_label, subject.label)
-        if subject.species:
-            self.fill(self._subject_species, subject.species)
+
+    def enter_subject_details(self, *, label: str | None = None, species: str | None = None) -> None:
+        if label is not None:
+            self.fill(self._subject_label, label)
+        if species is not None:
+            self.fill(self._subject_species, species)
+
+    def submit_subject_form(self) -> None:
         self.click(self._save_subject)
 
+    def add_subject(self, subject: Subject) -> None:
+        self.start_subject_creation()
+        self.enter_subject_details(label=subject.label, species=subject.species)
+        self.submit_subject_form()
+
     def subject_exists(self, subject: Subject) -> bool:
-        rows = self.elements(self._subject_table_rows)
-        return any(subject.label in row.text for row in rows)
+        rows = self.subject_rows()
+        if subject.species:
+            return any(subject.label in row and subject.species in row for row in rows)
+        return any(subject.label in row for row in rows)
+
+    def subject_rows(self) -> list[str]:
+        """Return the raw text contents of the subject table rows."""
+
+        return [row.text for row in self.elements(self._subject_table_rows)]
+
+    def subject_count(self) -> int:
+        """Return the number of subjects currently displayed."""
+
+        return len(self.elements(self._subject_table_rows))

--- a/src/xnat_selenium/pipeline.py
+++ b/src/xnat_selenium/pipeline.py
@@ -1,0 +1,162 @@
+"""Pipeline scheduling utilities inspired by the legacy test suite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import product
+from typing import Dict, List, Sequence, Set
+
+
+@dataclass(frozen=True)
+class DummyMethodInstance:
+    name: str
+    estimated_runtime: int | None = None
+    unit_test_ids: Set[int] | None = None
+
+    def __post_init__(self) -> None:
+        if self.unit_test_ids is None:
+            object.__setattr__(self, "unit_test_ids", frozenset())
+        else:
+            object.__setattr__(self, "unit_test_ids", frozenset(self.unit_test_ids))
+
+
+class UnitTestFilter:
+    """Helper that mimics the legacy ``UnitTestFilter`` utilities."""
+
+    _METHODS: Dict[str, DummyMethodInstance] = {
+        "testLaunch100": DummyMethodInstance("testLaunch100", 100, {1, 2}),
+        "testLaunch55": DummyMethodInstance("testLaunch55", 55, {1, 2}),
+        "testLaunch50": DummyMethodInstance("testLaunch50", 50, {1, 2}),
+        "testLaunch40": DummyMethodInstance("testLaunch40", 40, {1, 2}),
+        "testLaunch30": DummyMethodInstance("testLaunch30", 30, {1, 2}),
+        "testLaunch20": DummyMethodInstance("testLaunch20", 20, {1, 2}),
+        "testLaunch5": DummyMethodInstance("testLaunch5", 5, {1, 2}),
+        "testCheck100": DummyMethodInstance("testCheck100", unit_test_ids={1, 2}),
+        "testCheck55": DummyMethodInstance("testCheck55", unit_test_ids={1, 2}),
+        "testCheck50": DummyMethodInstance("testCheck50", unit_test_ids={1, 2}),
+        "testCheck40": DummyMethodInstance("testCheck40", unit_test_ids={1, 2}),
+        "testCheck30": DummyMethodInstance("testCheck30", unit_test_ids={1, 2}),
+        "testCheck20": DummyMethodInstance("testCheck20", unit_test_ids={1, 2}),
+        "testCheck5": DummyMethodInstance("testCheck5", unit_test_ids={1}),
+    }
+
+    _ORDER = [
+        "testLaunch100",
+        "testLaunch55",
+        "testLaunch50",
+        "testLaunch30",
+        "testLaunch40",
+        "testLaunch20",
+        "testLaunch5",
+        "testCheck100",
+        "testCheck55",
+        "testCheck50",
+        "testCheck40",
+        "testCheck30",
+        "testCheck20",
+        "testCheck5",
+    ]
+
+    @classmethod
+    def get_instance(cls, name: str) -> DummyMethodInstance:
+        return cls._METHODS[name]
+
+    @classmethod
+    def get_dummy_tests(cls, test_id: int) -> List[DummyMethodInstance]:
+        return [
+            cls._METHODS[name]
+            for name in cls._ORDER
+            if test_id in cls._METHODS[name].unit_test_ids
+        ]
+
+
+class PipelineMethodSorter:
+    """Schedules launch and check methods to mirror the Groovy tests."""
+
+    def order_by_job_shop_solution(
+        self, methods: Sequence[DummyMethodInstance], queue_slots: int
+    ) -> List[DummyMethodInstance]:
+        launch_methods = [
+            method
+            for method in methods
+            if method.name.startswith("testLaunch")
+        ]
+        if not launch_methods:
+            return list(methods)
+
+        assignments = self._solve_schedule(launch_methods, queue_slots)
+        ordered = list(launch_methods)
+        used = set(ordered)
+
+        completion = sorted(
+            assignments,
+            key=lambda item: (item.start + item.duration, item.queue_index),
+        )
+
+        for item in completion:
+            suffix = item.method.name[len("testLaunch") :]
+            check_name = f"testCheck{suffix}"
+            check_method = next(
+                (method for method in methods if method.name == check_name), None
+            )
+            if check_method is None:
+                raise RuntimeError(
+                    f"Could not find corresponding pipeline check test for launch test {item.method.name}."
+                )
+            if check_method not in used:
+                ordered.append(check_method)
+                used.add(check_method)
+
+        for method in methods:
+            if method not in used:
+                ordered.append(method)
+                used.add(method)
+
+        return ordered
+
+    def _solve_schedule(
+        self, methods: Sequence[DummyMethodInstance], queue_slots: int
+    ) -> Sequence["ScheduledJob"]:
+        best_assignment: Sequence[ScheduledJob] | None = None
+        best_makespan: int | None = None
+
+        for assignment in product(range(queue_slots), repeat=len(methods)):
+            queue_loads = [0] * queue_slots
+            schedule: List[ScheduledJob] = []
+            valid = True
+            for method, queue_index in zip(methods, assignment):
+                if method.estimated_runtime is None:
+                    valid = False
+                    break
+                start = queue_loads[queue_index]
+                duration = method.estimated_runtime
+                queue_loads[queue_index] += duration
+                schedule.append(
+                    ScheduledJob(
+                        method=method,
+                        queue_index=queue_index,
+                        start=start,
+                        duration=duration,
+                    )
+                )
+            if not valid:
+                continue
+            makespan = max(queue_loads)
+            if best_makespan is None or makespan < best_makespan or (
+                makespan == best_makespan and assignment < tuple(job.queue_index for job in best_assignment)
+            ):
+                best_assignment = schedule
+                best_makespan = makespan
+
+        if best_assignment is None:
+            return []
+        return best_assignment
+
+
+@dataclass(frozen=True)
+class ScheduledJob:
+    method: DummyMethodInstance
+    queue_index: int
+    start: int
+    duration: int
+

--- a/src/xnat_selenium/xpath.py
+++ b/src/xnat_selenium/xpath.py
@@ -1,0 +1,45 @@
+"""Utility classes for composing XPaths mirroring the Groovy helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class XpathLocator:
+    expression: str
+
+    def join_sublocator(self, sublocator: str) -> "XpathLocator":
+        trimmed = sublocator.strip()
+        if trimmed.startswith("./"):
+            trimmed = trimmed[2:]
+        elif trimmed.startswith("/"):
+            trimmed = trimmed[1:]
+        if not trimmed:
+            return XpathLocator(self.expression)
+        return XpathLocator(f"{self.expression}/{trimmed}")
+
+    def nth_instance(self, index: int) -> "XpathLocator":
+        return XpathLocator(f"({self.expression})[{index}]")
+
+    def parent(self) -> "XpathLocator":
+        return XpathLocator(f"{self.expression}/..")
+
+    def grandparent(self) -> "XpathLocator":
+        return XpathLocator(f"{self.expression}/../..")
+
+    def union_sublocators(self, sublocators: Sequence["XpathLocator"]) -> "XpathUnion":
+        joined = [self.join_sublocator(locator.expression) for locator in sublocators]
+        return XpathUnion(joined)
+
+
+@dataclass(frozen=True)
+class XpathUnion:
+    locators: Sequence[XpathLocator]
+
+    @property
+    def expression(self) -> str:
+        joined = " | ".join(locator.expression for locator in self.locators)
+        return f"({joined})"
+

--- a/tests/resources/sample_element_specifications.yaml
+++ b/tests/resources/sample_element_specifications.yaml
@@ -1,0 +1,27 @@
+comparators:
+  - type: Equals
+    elements:
+      - locator: //my/div[3]
+        value: happy
+      - locator: //my/div[4]
+        value: '3.00'
+      - locator:
+          type: xpath
+          value: //my/div[5]
+        value: cat
+      - locator:
+          type: id
+          value: summary
+        value: passed
+  - type: maxPercentTolerance
+    percent: 1.0
+    elements:
+      - locator: $summary_tbody/tr[$indexCache(Left-Pallidum)]/td[2]
+        value: 100000.0
+locatorCaches:
+  - id: indexCache
+    type: textIndexArray
+    locator: "//span[@id='full_summary']//tbody/tr/td[1]"
+    offset: 2
+locatorReplacements:
+  '$summary_tbody': "//span[@id='full_summary']//tbody"

--- a/tests/resources/sample_element_specifications_serialized.yaml
+++ b/tests/resources/sample_element_specifications_serialized.yaml
@@ -1,0 +1,25 @@
+comparators:
+- type: Equals
+  elements:
+  - locator: "//my/div[3]"
+    value: happy
+  - locator: "//my/div[4]"
+    value: 3.00
+  - locator: "//my/div[5]"
+    value: cat
+  - locator:
+      type: id
+      value: summary
+    value: passed
+- type: maxPercentTolerance
+  percent: 1.0
+  elements:
+  - locator: "$summary_tbody/tr[$indexCache(Left-Pallidum)]/td[2]"
+    value: 100000.0
+locatorCaches:
+- !<textIndexArray>
+  id: indexCache
+  locator: "//span[@id='full_summary']//tbody/tr/td[1]"
+  offset: 2
+locatorReplacements:
+  $summary_tbody: "//span[@id='full_summary']//tbody"

--- a/tests/test_browser_support.py
+++ b/tests/test_browser_support.py
@@ -1,0 +1,31 @@
+from xnat_selenium.browser import BrowserSupport, ChromeSupport, FirefoxSupport
+
+
+def setup_function():
+    BrowserSupport.clear_cache()
+
+
+def test_browser_caching_variants():
+    BrowserSupport.cache_browser("Chrome")
+    assert BrowserSupport.cached_browser_support is ChromeSupport
+    BrowserSupport.clear_cache()
+
+    BrowserSupport.cache_browser("FF")
+    assert BrowserSupport.cached_browser_support is FirefoxSupport
+    BrowserSupport.clear_cache()
+
+    BrowserSupport.cache_browser("Google Chrome")
+    assert BrowserSupport.cached_browser_support is ChromeSupport
+
+
+def test_unknown_browser_reports_available_options():
+    try:
+        BrowserSupport.cache_browser("MicrosoftEdge")
+    except RuntimeError as error:
+        message = str(error)
+        assert "Unknown browser: MicrosoftEdge" in message
+        assert "Chrome" in message
+        assert "MozillaFirefox" in message
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected RuntimeError to be raised for unknown browser")
+

--- a/tests/test_dashboard_navigation.py
+++ b/tests/test_dashboard_navigation.py
@@ -1,0 +1,34 @@
+"""Navigation and session management tests for the XNAT UI."""
+from __future__ import annotations
+
+import pytest
+
+from xnat_selenium.pages.dashboard import DashboardPage
+from xnat_selenium.pages.login import LoginPage
+from xnat_selenium.pages.projects import ProjectsPage
+
+
+@pytest.mark.smoke
+@pytest.mark.projects
+def test_dashboard_links_to_projects(dashboard, xnat_config):
+    """Selecting the projects option should load the project listing."""
+
+    dashboard.go_to_projects()
+
+    projects_page = ProjectsPage(dashboard.driver, xnat_config.base_url)
+    assert projects_page.is_loaded(), "Projects page did not finish loading"
+
+
+@pytest.mark.smoke
+def test_user_can_logout(driver, xnat_config):
+    """Logging out returns the user to the login screen."""
+
+    login_page = LoginPage(driver, xnat_config.base_url).open()
+    login_page.login(xnat_config.username, xnat_config.password)
+
+    dashboard = DashboardPage(driver, xnat_config.base_url)
+    dashboard.wait_until_loaded()
+    dashboard.logout()
+
+    login_page = LoginPage(driver, xnat_config.base_url)
+    assert login_page.is_displayed(), "Login screen was not displayed after logout"

--- a/tests/test_element_specifications.py
+++ b/tests/test_element_specifications.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from xnat_selenium.element_specifications import (
+    Element,
+    ElementSpecifications,
+    EqualityElementComparator,
+    Locator,
+    MaxPercentToleranceElementComparator,
+    TextIndexArray,
+)
+
+
+def compose_specifications() -> ElementSpecifications:
+    return ElementSpecifications(
+        comparators=(
+            EqualityElementComparator(
+                (
+                    Element(Locator("xpath", "//my/div[3]"), "happy"),
+                    Element(Locator("xpath", "//my/div[4]"), Decimal("3.00")),
+                    Element(Locator("xpath", "//my/div[5]"), "cat"),
+                    Element(Locator("id", "summary"), "passed"),
+                )
+            ),
+            MaxPercentToleranceElementComparator(
+                Decimal("1.0"),
+                (
+                    Element(
+                        Locator(
+                            "xpath",
+                            "$summary_tbody/tr[$indexCache(Left-Pallidum)]/td[2]",
+                        ),
+                        Decimal("100000.0"),
+                    ),
+                ),
+            ),
+        ),
+        locator_caches=(
+            TextIndexArray(
+                id="indexCache",
+                locator="//span[@id='full_summary']//tbody/tr/td[1]",
+                offset=2,
+            ),
+        ),
+        locator_replacements={
+            "$summary_tbody": "//span[@id='full_summary']//tbody"
+        },
+    )
+
+
+def test_deserialize_sample_file():
+    payload = Path("tests/resources/sample_element_specifications.yaml").read_text()
+    assert ElementSpecifications.from_yaml(payload) == compose_specifications()
+
+
+def test_serialize_matches_sample_output():
+    expected = Path(
+        "tests/resources/sample_element_specifications_serialized.yaml"
+    ).read_text()
+    assert compose_specifications().to_yaml() == expected
+
+
+def test_round_trip_preserves_payload():
+    spec = compose_specifications()
+    assert ElementSpecifications.from_yaml(spec.to_yaml()) == spec
+

--- a/tests/test_page_object_registry.py
+++ b/tests/test_page_object_registry.py
@@ -1,0 +1,66 @@
+from xnat_selenium.page_registry import (
+    PageObjectRegistry,
+    XnatPageComponent,
+    Xnat_1_6dev,
+    Xnat_1_7_2,
+    Xnat_1_7_3,
+    Xnat_1_7_4,
+    Xnat_1_7_5,
+    Xnat_1_7_5_2,
+    Xnat_1_7_7,
+)
+
+
+PageObjectRegistry.clear()
+
+
+@PageObjectRegistry.register
+class DummyPageComponent(XnatPageComponent):
+    handled_versions = (Xnat_1_7_7, Xnat_1_7_5_2)
+
+
+@PageObjectRegistry.register
+class DummyPageComponent1_7_5(DummyPageComponent):
+    handled_versions = (Xnat_1_7_5, Xnat_1_7_4)
+
+
+@PageObjectRegistry.register
+class DummyPageComponent1_7_3(DummyPageComponent1_7_5):
+    handled_versions = (Xnat_1_7_3, Xnat_1_7_2)
+
+
+@PageObjectRegistry.register
+class DummyPageComponent1_6(DummyPageComponent1_7_3):
+    handled_versions = (Xnat_1_6dev,)
+
+
+def test_page_object_lookup_prefers_most_specific_version():
+    assert (
+        PageObjectRegistry.get_page_object(DummyPageComponent, Xnat_1_7_7)
+        is DummyPageComponent
+    )
+    assert (
+        PageObjectRegistry.get_page_object(DummyPageComponent, Xnat_1_7_5_2)
+        is DummyPageComponent
+    )
+    assert (
+        PageObjectRegistry.get_page_object(DummyPageComponent, Xnat_1_7_5)
+        is DummyPageComponent1_7_5
+    )
+    assert (
+        PageObjectRegistry.get_page_object(DummyPageComponent, Xnat_1_7_4)
+        is DummyPageComponent1_7_5
+    )
+    assert (
+        PageObjectRegistry.get_page_object(DummyPageComponent, Xnat_1_7_3)
+        is DummyPageComponent1_7_3
+    )
+    assert (
+        PageObjectRegistry.get_page_object(DummyPageComponent, Xnat_1_7_2)
+        is DummyPageComponent1_7_3
+    )
+    assert (
+        PageObjectRegistry.get_page_object(DummyPageComponent, Xnat_1_6dev)
+        is DummyPageComponent1_6
+    )
+

--- a/tests/test_pipeline_method_sorter.py
+++ b/tests/test_pipeline_method_sorter.py
@@ -1,0 +1,41 @@
+from xnat_selenium.pipeline import PipelineMethodSorter, UnitTestFilter
+
+
+def test_pipeline_sorting_matches_reference_behaviour():
+    sorter = PipelineMethodSorter()
+    launch100 = UnitTestFilter.get_instance("testLaunch100")
+    launch55 = UnitTestFilter.get_instance("testLaunch55")
+    launch50 = UnitTestFilter.get_instance("testLaunch50")
+    launch40 = UnitTestFilter.get_instance("testLaunch40")
+    launch30 = UnitTestFilter.get_instance("testLaunch30")
+    launch20 = UnitTestFilter.get_instance("testLaunch20")
+    launch5 = UnitTestFilter.get_instance("testLaunch5")
+    check55 = UnitTestFilter.get_instance("testCheck55")
+    check50 = UnitTestFilter.get_instance("testCheck50")
+    check40 = UnitTestFilter.get_instance("testCheck40")
+    check30 = UnitTestFilter.get_instance("testCheck30")
+
+    ordered = sorter.order_by_job_shop_solution(
+        UnitTestFilter.get_dummy_tests(1), 3
+    )
+
+    expected_prefix = [
+        [launch100, launch55, launch50, launch30, launch40, launch20, launch5],
+        [launch100, launch50, launch55, launch30, launch40, launch20, launch5],
+    ]
+    assert ordered[:7] in expected_prefix
+    assert ordered[7:11] == [check50, check55, check30, check40]
+
+
+def test_missing_check_test_raises_error():
+    sorter = PipelineMethodSorter()
+    try:
+        sorter.order_by_job_shop_solution(UnitTestFilter.get_dummy_tests(2), 3)
+    except RuntimeError as error:
+        assert (
+            str(error)
+            == "Could not find corresponding pipeline check test for launch test testLaunch5."
+        )
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected RuntimeError to be raised when check test missing")
+

--- a/tests/test_project_details_tab.py
+++ b/tests/test_project_details_tab.py
@@ -1,0 +1,69 @@
+"""Unit tests mirroring legacy behaviours from the Bitbucket suite."""
+from __future__ import annotations
+
+import pytest
+
+from xnat_selenium.pages.project_details import LegacyProjectDetailsTab, ProjectDetailsTab
+from xnat_selenium.pages.projects import Project
+
+
+@pytest.mark.projects
+@pytest.mark.parametrize(
+    "tab_cls, expected",
+    [
+        (ProjectDetailsTab, "Functional & Research"),
+        (LegacyProjectDetailsTab, "Functional &amp Research"),
+    ],
+)
+def test_escape_on_project_page_matches_version_behaviour(tab_cls, expected):
+    """Legacy versions escaped HTML entities while modern builds do not."""
+
+    tab = tab_cls()
+    assert tab.escape_on_project_page("Functional & Research") == expected
+
+
+@pytest.mark.projects
+@pytest.mark.parametrize(
+    "tab_cls, aliases, expected",
+    [
+        (ProjectDetailsTab, ("XG 001",), "XG001 Aka: XG 001"),
+        (LegacyProjectDetailsTab, ("XG & 001",), "XG001 Aka: XG &amp 001"),
+    ],
+)
+def test_expected_project_id_string_includes_aliases(tab_cls, aliases, expected):
+    project = Project(identifier="XG001", name="XNAT Growth", aliases=aliases)
+    tab = tab_cls()
+    assert tab.expected_project_id_string(project) == expected
+
+
+@pytest.mark.projects
+@pytest.mark.parametrize("tab_cls", [ProjectDetailsTab, LegacyProjectDetailsTab])
+def test_render_helpers_respect_escape_strategy(tab_cls):
+    description = "Detailed <overview> & planning"
+    keywords = ("longitudinal", "analysis & planning")
+    project = Project(
+        identifier="XG002",
+        name="Secondary",
+        description=description,
+        keywords=keywords,
+    )
+
+    tab = tab_cls()
+    rendered_description = tab.render_description(project)
+    rendered_keywords = tab.render_keywords(project)
+
+    if tab_cls is LegacyProjectDetailsTab:
+        assert rendered_description == "Detailed &ltoverview&gt &amp planning"
+        assert rendered_keywords == "longitudinal analysis &amp planning"
+    else:
+        assert rendered_description == description
+        assert rendered_keywords == "longitudinal analysis & planning"
+
+
+@pytest.mark.projects
+@pytest.mark.parametrize("tab_cls", [ProjectDetailsTab, LegacyProjectDetailsTab])
+def test_render_helpers_handle_missing_data(tab_cls):
+    project = Project(identifier="XG003", name="Tertiary")
+    tab = tab_cls()
+    assert tab.render_description(project) is None
+    assert tab.render_keywords(project) == ""

--- a/tests/test_project_lifecycle.py
+++ b/tests/test_project_lifecycle.py
@@ -49,3 +49,42 @@ def test_project_subject_and_experiment_creation(driver, xnat_config):
         )
     finally:
         DashboardPage(driver, xnat_config.base_url).logout()
+
+
+@pytest.mark.e2e
+@pytest.mark.projects
+def test_project_with_subject_species_and_experiment_modality(driver, xnat_config):
+    """Optional subject and experiment fields should be persisted."""
+
+    identifier = f"AUTO{uuid.uuid4().hex[:6]}"
+    project = Project(identifier=identifier, name=f"Optional Fields {identifier}")
+    subject = Subject(label=f"SUBJ-{uuid.uuid4().hex[:6]}", species="Homo sapiens")
+    experiment = Experiment(label=f"EXP-{uuid.uuid4().hex[:6]}", modality="MR")
+
+    login_page = LoginPage(driver, xnat_config.base_url).open()
+    login_page.login(xnat_config.username, xnat_config.password)
+    dashboard = DashboardPage(driver, xnat_config.base_url)
+    dashboard.wait_until_loaded()
+
+    try:
+        dashboard.go_to_projects()
+
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        projects_page.create_project(project)
+        projects_page.open()
+        projects_page.wait_until(lambda drv: projects_page.project_exists(project), message="project to appear in table")
+
+        subjects_page = SubjectsPage(driver, xnat_config.base_url)
+        subjects_page.open(project.identifier)
+        subjects_page.add_subject(subject)
+        subjects_page.wait_until(lambda drv: subjects_page.subject_exists(subject), message="subject to appear in table")
+
+        experiments_page = ExperimentsPage(driver, xnat_config.base_url)
+        experiments_page.open(project.identifier, subject.label)
+        experiments_page.add_experiment(experiment)
+        experiments_page.wait_until(
+            lambda drv: experiments_page.experiment_exists(experiment), message="experiment to appear in table"
+        )
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()

--- a/tests/test_project_management.py
+++ b/tests/test_project_management.py
@@ -1,0 +1,103 @@
+"""Project management scenarios inspired by the upstream Bitbucket suite."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from xnat_selenium.pages.dashboard import DashboardPage
+from xnat_selenium.pages.login import LoginPage
+from xnat_selenium.pages.projects import Project, ProjectsPage
+
+
+def _login_to_dashboard(driver, xnat_config) -> DashboardPage:
+    login_page = LoginPage(driver, xnat_config.base_url).open()
+    login_page.login(xnat_config.username, xnat_config.password)
+    dashboard = DashboardPage(driver, xnat_config.base_url)
+    dashboard.wait_until_loaded()
+    return dashboard
+
+
+@pytest.mark.projects
+def test_project_description_persisted_in_listing(driver, xnat_config):
+    """Creating a project with a description should display that description."""
+
+    dashboard = _login_to_dashboard(driver, xnat_config)
+    project_id = f"AUTO{uuid.uuid4().hex[:6]}"
+    project = Project(identifier=project_id, name=f"Project {project_id}", description="Functional imaging study")
+
+    try:
+        dashboard.go_to_projects()
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        projects_page.create_project(project)
+        projects_page.open()
+
+        rows = projects_page.project_rows()
+        matching_rows = [row for row in rows if project.identifier in row]
+        assert matching_rows, "Project was not listed after creation"
+        assert project.description in matching_rows[0], "Project description was not rendered in the listing"
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()
+
+
+@pytest.mark.projects
+def test_recreating_project_updates_existing_entry(driver, xnat_config):
+    """Reusing an identifier should update the existing project record instead of duplicating it."""
+
+    dashboard = _login_to_dashboard(driver, xnat_config)
+    project_id = f"AUTO{uuid.uuid4().hex[:6]}"
+    original = Project(identifier=project_id, name=f"Baseline {project_id}", description="Initial")
+    updated = Project(identifier=project_id, name=f"Updated {project_id}", description="Updated description")
+
+    try:
+        dashboard.go_to_projects()
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        projects_page.create_project(original)
+        projects_page.open()
+        projects_page.create_project(updated)
+        projects_page.open()
+
+        rows = projects_page.project_rows()
+        matching_rows = [row for row in rows if project_id in row]
+        assert matching_rows, "Updated project was not listed"
+        row_text = matching_rows[0]
+        assert updated.name in row_text, "Project name was not updated when reusing the identifier"
+        assert updated.description in row_text, "Project description was not updated when reusing the identifier"
+        assert original.description not in row_text, "Stale project details remained after update"
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()
+
+
+@pytest.mark.projects
+def test_project_creation_requires_identifier_and_name(driver, xnat_config):
+    """Attempting to submit an incomplete project form should not add rows to the listing."""
+
+    dashboard = _login_to_dashboard(driver, xnat_config)
+    project_id = f"AUTO{uuid.uuid4().hex[:6]}"
+
+    try:
+        dashboard.go_to_projects()
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        initial_count = projects_page.project_count()
+
+        # Missing identifier
+        projects_page.start_project_creation()
+        projects_page.enter_project_details(name="Missing Identifier")
+        projects_page.submit_project_form()
+        assert projects_page.project_count() == initial_count, "Project without identifier should not be created"
+
+        # Missing name
+        projects_page.enter_project_details(identifier=project_id, name="")
+        projects_page.submit_project_form()
+        assert projects_page.project_count() == initial_count, "Project without a name should not be created"
+
+        # Valid project after validation checks
+        valid_project = Project(identifier=project_id, name=f"Valid {project_id}")
+        projects_page.create_project(valid_project)
+        projects_page.open()
+        assert projects_page.project_count() == initial_count + 1, "Valid project was not created after validation retries"
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()

--- a/tests/test_subject_and_experiment_management.py
+++ b/tests/test_subject_and_experiment_management.py
@@ -1,0 +1,148 @@
+"""Subject and experiment workflows adapted from the Bitbucket reference suite."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from xnat_selenium.pages.dashboard import DashboardPage
+from xnat_selenium.pages.experiments import Experiment, ExperimentsPage
+from xnat_selenium.pages.login import LoginPage
+from xnat_selenium.pages.projects import Project, ProjectsPage
+from xnat_selenium.pages.subjects import Subject, SubjectsPage
+
+
+def _login_to_dashboard(driver, xnat_config) -> DashboardPage:
+    login_page = LoginPage(driver, xnat_config.base_url).open()
+    login_page.login(xnat_config.username, xnat_config.password)
+    dashboard = DashboardPage(driver, xnat_config.base_url)
+    dashboard.wait_until_loaded()
+    return dashboard
+
+
+@pytest.mark.projects
+@pytest.mark.subjects
+def test_duplicate_subject_updates_species(driver, xnat_config):
+    """Re-adding a subject should refresh its metadata instead of creating duplicates."""
+
+    dashboard = _login_to_dashboard(driver, xnat_config)
+    project_id = f"AUTO{uuid.uuid4().hex[:6]}"
+    project = Project(identifier=project_id, name=f"Project {project_id}")
+    subject_label = f"SUBJ-{uuid.uuid4().hex[:6]}"
+
+    try:
+        dashboard.go_to_projects()
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        projects_page.create_project(project)
+        projects_page.open()
+
+        subjects_page = SubjectsPage(driver, xnat_config.base_url)
+        subjects_page.open(project.identifier)
+        subjects_page.add_subject(Subject(label=subject_label, species="Homo sapiens"))
+        subjects_page.add_subject(Subject(label=subject_label, species="Pan troglodytes"))
+
+        rows = subjects_page.subject_rows()
+        matching_rows = [row for row in rows if subject_label in row]
+        assert matching_rows, "Subject did not appear in the listing"
+        row_text = matching_rows[0]
+        assert "Pan troglodytes" in row_text, "Updated species was not visible after re-adding subject"
+        assert "Homo sapiens" not in row_text, "Stale species information remained after update"
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()
+
+
+@pytest.mark.projects
+@pytest.mark.subjects
+def test_subject_creation_requires_label(driver, xnat_config):
+    """Submitting the subject form without a label should not add to the table."""
+
+    dashboard = _login_to_dashboard(driver, xnat_config)
+    project_id = f"AUTO{uuid.uuid4().hex[:6]}"
+    project = Project(identifier=project_id, name=f"Project {project_id}")
+
+    try:
+        dashboard.go_to_projects()
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        projects_page.create_project(project)
+        projects_page.open()
+
+        subjects_page = SubjectsPage(driver, xnat_config.base_url)
+        subjects_page.open(project.identifier)
+        subjects_page.start_subject_creation()
+        subjects_page.enter_subject_details(species="Homo sapiens")
+        subjects_page.submit_subject_form()
+
+        assert subjects_page.subject_count() == 0, "Subject without a label should not be persisted"
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()
+
+
+@pytest.mark.projects
+@pytest.mark.experiments
+def test_duplicate_experiment_updates_modality(driver, xnat_config):
+    """Experiment metadata should be replaced when the same label is submitted twice."""
+
+    dashboard = _login_to_dashboard(driver, xnat_config)
+    project_id = f"AUTO{uuid.uuid4().hex[:6]}"
+    project = Project(identifier=project_id, name=f"Project {project_id}")
+    subject = Subject(label=f"SUBJ-{uuid.uuid4().hex[:6]}")
+    experiment_label = f"EXP-{uuid.uuid4().hex[:6]}"
+
+    try:
+        dashboard.go_to_projects()
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        projects_page.create_project(project)
+        projects_page.open()
+
+        subjects_page = SubjectsPage(driver, xnat_config.base_url)
+        subjects_page.open(project.identifier)
+        subjects_page.add_subject(subject)
+
+        experiments_page = ExperimentsPage(driver, xnat_config.base_url)
+        experiments_page.open(project.identifier, subject.label)
+        experiments_page.add_experiment(Experiment(label=experiment_label, modality="MR"))
+        experiments_page.add_experiment(Experiment(label=experiment_label, modality="PET"))
+
+        rows = experiments_page.experiment_rows()
+        matching_rows = [row for row in rows if experiment_label in row]
+        assert matching_rows, "Experiment did not appear in the listing"
+        row_text = matching_rows[0]
+        assert "PET" in row_text, "Updated modality was not visible after re-adding experiment"
+        assert "MR" not in row_text, "Stale modality information remained after update"
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()
+
+
+@pytest.mark.projects
+@pytest.mark.experiments
+def test_experiment_creation_requires_label(driver, xnat_config):
+    """Submitting the experiment form without a label should not create a session."""
+
+    dashboard = _login_to_dashboard(driver, xnat_config)
+    project_id = f"AUTO{uuid.uuid4().hex[:6]}"
+    project = Project(identifier=project_id, name=f"Project {project_id}")
+    subject = Subject(label=f"SUBJ-{uuid.uuid4().hex[:6]}")
+
+    try:
+        dashboard.go_to_projects()
+        projects_page = ProjectsPage(driver, xnat_config.base_url)
+        projects_page.open()
+        projects_page.create_project(project)
+        projects_page.open()
+
+        subjects_page = SubjectsPage(driver, xnat_config.base_url)
+        subjects_page.open(project.identifier)
+        subjects_page.add_subject(subject)
+
+        experiments_page = ExperimentsPage(driver, xnat_config.base_url)
+        experiments_page.open(project.identifier, subject.label)
+        experiments_page.start_experiment_creation()
+        experiments_page.enter_experiment_details(modality="CT")
+        experiments_page.submit_experiment_form()
+
+        assert experiments_page.experiment_count() == 0, "Experiment without a label should not be persisted"
+    finally:
+        DashboardPage(driver, xnat_config.base_url).logout()

--- a/tests/test_xpath_locator.py
+++ b/tests/test_xpath_locator.py
@@ -1,0 +1,33 @@
+from xnat_selenium.xpath import XpathLocator, XpathUnion
+
+
+def test_join_sublocator_handles_relative_paths():
+    base = XpathLocator("//div[@id='archive']")
+    assert base.join_sublocator("./div[3]").expression == "//div[@id='archive']/div[3]"
+    assert base.join_sublocator("/div[3]").expression == "//div[@id='archive']/div[3]"
+
+
+def test_nth_instance_wraps_expression():
+    assert XpathLocator("//div/div/div").nth_instance(3).expression == "(//div/div/div)[3]"
+
+
+def test_parent_helpers():
+    locator = XpathLocator("//div/div")
+    assert locator.parent().expression == "//div/div/.."
+    assert locator.grandparent().expression == "//div/div/../.."
+
+
+def test_union_helpers():
+    union = XpathUnion(
+        [XpathLocator("//div"), XpathLocator("//div/span"), XpathLocator("//span/div")]
+    )
+    assert union.expression == "(//div | //div/span | //span/div)"
+
+
+def test_union_sublocators():
+    base = XpathLocator("//div")
+    result = base.union_sublocators(
+        [XpathLocator("./div/span"), XpathLocator("./table/tbody")]
+    )
+    assert result.expression == "(//div/div/span | //div/table/tbody)"
+


### PR DESCRIPTION
## Summary
- add lightweight browser support, XPath, pipeline scheduling, and page registry helpers mirroring the Bitbucket suite
- port the element specification marshalling utilities together with their reference YAML fixtures
- translate the Bitbucket browser, XPath, pipeline, element specification, and page registry tests into pytest modules

## Testing
- PYTHONPATH=src XNAT_USE_MOCK=1 pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1d619a4408321b1dfb9e1f5cd23b9