### PR TITLE
Add pytest report for remote test suite execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local test environment assets
 .xnat-test-env/
+.venv/
 
 # Python bytecode caches
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -19,11 +19,16 @@ be validated automatically.
 
 ## Getting started
 
-1. Install dependencies (Python 3.10+):
+1. Create the local virtual environment (Python 3.10+) and install the
+   project dependencies:
 
    ```bash
-   pip install -e .
+   ./scripts/setup_venv.sh
    ```
+
+   The script provisions `.venv/`, upgrades `pip`, and installs the package in
+   editable mode so that subsequent changes to the test suite are immediately
+   available when the environment is activated.
 
 2. Provide credentials and connection details for the target XNAT environment
    using environment variables or Pytest command line flags:

--- a/reports/test_report_2025-02-15.md
+++ b/reports/test_report_2025-02-15.md
@@ -1,0 +1,25 @@
+# Pytest Execution Report
+
+- **Command:** `source .venv/bin/activate && python3 -m pytest tests --base-url="https://crdemo.dev.xnatworks.io" --username="admin" --password="admin"`
+- **Date:** 2025-10-05 21:16:35Z
+
+## Summary
+- **Total tests:** 35
+- **Passed:** 21
+- **Skipped:** 14
+- **Failed:** 0
+- **Warnings:** 1 (`RuntimeWarning` about the base URL returning HTTP 503 on HEAD request)
+
+## Skipped Test Reasons
+All skipped tests failed to start the Selenium Chrome driver in the containerized environment:
+- `tests/test_dashboard_navigation.py` (2 tests)
+- `tests/test_login.py` (3 tests)
+- `tests/test_project_lifecycle.py` (2 tests)
+- `tests/test_project_management.py` (3 tests)
+- `tests/test_subject_and_experiment_management.py` (4 tests)
+
+Each skip reported: *"Unable to obtain driver for chrome"* with a link to Selenium driver troubleshooting guidance.
+
+## Additional Notes
+- The HEAD request to `https://crdemo.dev.xnatworks.io` returned HTTP 503, but the test suite continued after logging a warning.
+- Review the test infrastructure to ensure the required Chrome driver and browser binaries are available when running Selenium UI tests.

--- a/scripts/setup_venv.sh
+++ b/scripts/setup_venv.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to create the virtual environment" >&2
+  exit 1
+fi
+
+VENV_DIR=".venv"
+
+if [ ! -d "$VENV_DIR" ]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+python -m pip install --upgrade pip
+
+if [ -f "requirements.txt" ]; then
+  pip install -r requirements.txt
+else
+  pip install -e .
+fi
+
+deactivate
+
+echo "Virtual environment ready at $VENV_DIR"


### PR DESCRIPTION
## Summary
- add a dated pytest execution report detailing the latest run against https://crdemo.dev.xnatworks.io

## Testing
- source .venv/bin/activate && python3 -m pytest tests --base-url="https://crdemo.dev.xnatworks.io" --username="admin" --password="admin"

------
https://chatgpt.com/codex/tasks/task_e_68e2de8638488321a7a207ecef116f9e